### PR TITLE
Add a method to extract in ical format

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -38,4 +38,11 @@ interface Adapter
 	 */
 	public function extractFromString(string $source): array;
 
+	/**
+	 * @param string $source
+	 * @return string ics/ical event
+	 * @throws KItineraryRuntimeException
+	 */
+	public function extractIcalFromString(string $source): string;
+
 }


### PR DESCRIPTION
The idea is to then add the method to the adapters and pass the `-o ical` option to the kitinerary binary to get ical format and be able to directly inject the result in a calendar. If you approve this I can create the PRs on all adapters to add support for that.

Signed-off-by: Côme Chilliet <come@chilliet.eu>